### PR TITLE
Add client and Salesorder Stream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+
+setup(name='tap-x-y',
+      version='0.0.1',
+      description='Singer.io tap for extracting data from the XY API',
+      author='scott.coleman@bytecode.io',
+      classifiers=['Programming Language :: Python :: 3 :: Only'],
+      py_modules=['tap_ms_teams'],
+      install_requires=[
+          'singer-python==5.9.0',
+          'backoff==1.8.0',
+          'requests==2.23.0',
+          'pyhumps==1.6.1'
+      ],
+      extras_require={
+          'dev': [
+              'pylint',
+              'ipdb',
+              'nose',
+          ]
+      },
+      python_requires='>=3.5.6',
+      entry_points='''
+          [console_scripts]
+          tap-x-y=tap_x_y:main
+      ''',
+      packages=find_packages(),
+      package_data={
+          'tap_x_y': [
+              'schemas/*.json'
+          ]
+      })

--- a/tap_x_y/__init__.py
+++ b/tap_x_y/__init__.py
@@ -1,0 +1,88 @@
+import json
+
+import singer
+from singer import Transformer, metadata
+from singer.utils import strftime, strptime_to_utc
+import sys
+from tap_x_y.streams import AVAILABLE_STREAMS
+from tap_x_y.client import XYClient
+from tap_x_y.catalog import generate_catalog
+
+
+LOGGER = singer.get_logger()
+
+
+def discover(client):
+    LOGGER.info('Starting Discovery..')
+    streams = [
+        stream_class(client) for _, stream_class in AVAILABLE_STREAMS.items()
+    ]
+    catalog = generate_catalog(streams)
+    json.dump(catalog, sys.stdout, indent=2)
+
+
+def sync(client, config, catalog, state):
+    LOGGER.info('Starting Sync..')
+    selected_streams = catalog.get_selected_streams(state)
+
+    streams = []
+    stream_keys = []
+    with Transformer() as transformer:
+        for catalog_entry in selected_streams:
+            streams.append(catalog_entry)
+            stream_keys.append(catalog_entry.stream)
+
+        for catalog_entry in streams:
+            stream = AVAILABLE_STREAMS[catalog_entry.stream](client=client,
+                                                             config=config,
+                                                             catalog=catalog,
+                                                             state=state)
+            LOGGER.info('Syncing stream: %s', catalog_entry.stream)
+
+            stream.write_state()
+
+            bookmark_date = stream.get_bookmark(stream.name,
+                                                config['start_date'])
+            bookmark_dttm = strptime_to_utc(bookmark_date)
+
+            stream_schema = catalog_entry.schema.to_dict()
+            stream.write_schema()
+            stream_metadata = metadata.to_map(catalog_entry.metadata)
+            max_bookmark_value = None
+            with singer.metrics.job_timer(job_type=stream.name) as timer:
+                with singer.metrics.record_counter(
+                        endpoint=stream.name) as counter:
+                    for page in stream.sync(catalog_entry.metadata):
+                        for record in page:
+                            singer.write_record(
+                                catalog_entry.stream,
+                                transformer.transform(
+                                    record,
+                                    stream_schema,
+                                    stream_metadata,
+                                ))
+                            counter.increment()
+                        stream.update_bookmark(stream.name,
+                                                max_bookmark_value)
+                        stream.write_state()
+
+        stream.write_state()
+        LOGGER.info('Finished Sync..')
+
+
+def main():
+    parsed_args = singer.utils.parse_args(required_config_keys=[
+        'token'
+    ])
+    config = parsed_args.config
+
+    client = XYClient(config)
+
+    if parsed_args.discover:
+        discover(client=client)
+    elif parsed_args.catalog:
+        sync(client, config, parsed_args.catalog, parsed_args.state)
+
+
+if __name__ == '__main__':
+    main()

--- a/tap_x_y/catalog.py
+++ b/tap_x_y/catalog.py
@@ -1,0 +1,21 @@
+import singer
+
+def generate_catalog(streams):
+
+    catalog = {}
+    catalog['streams'] = []
+    for stream in streams:
+        schema = stream.load_schema()
+        catalog_entry = {
+            'stream': stream.name,
+            'tap_stream_id': stream.name,
+            'schema': schema,
+            'metadata': singer.metadata.get_standard_metadata(
+                schema=schema,
+                key_properties=stream.key_properties,
+                valid_replication_keys=stream.valid_replication_keys,
+                replication_method=stream.replication_method)
+        }
+        catalog['streams'].append(catalog_entry)
+
+    return catalog

--- a/tap_x_y/client.py
+++ b/tap_x_y/client.py
@@ -1,0 +1,71 @@
+import requests
+import singer
+import urllib
+
+
+
+LOGGER = singer.get_logger()  # noqa
+PAGE_SIZE = 100
+BASE_URL = "https://developer.xyretail.com"
+
+class XYClient:
+
+    def __init__(self, config):
+        self.config = config
+        self.session = requests.Session()
+        self.access_token = config.get('token')
+
+    def build_url(self, baseurl, path, args_dict):
+        # Returns a list in the structure of urlparse.ParseResult
+        url_parts = list(urllib.parse.urlparse(baseurl))
+        url_parts[2] = '_g' + '/' + path
+        url_parts[4] = urllib.parse.urlencode(args_dict)
+        return urllib.parse.urlunparse(url_parts)
+
+    def get_resources(self, path, filter_param):
+        page_from = 0
+        total = 1
+
+        args = {
+            'size': 100,
+            'from': page_from
+        }
+        args = {**args, **filter_param}
+
+        next = self.build_url(BASE_URL, path, args)
+
+        data = []
+        rows_in_response = 1
+        while rows_in_response > 0:
+            response = self.make_request(method='GET', url=next)
+            total = response.get('total')
+            data.extend(response.get('rows'))
+            rows_in_response = len(response.get('rows'))
+            page_from += PAGE_SIZE
+            args['from'] = page_from + 101
+            args['total'] = total
+            next = self.build_url(BASE_URL, path, args)
+        return data
+
+    def make_request(self,
+                     method,
+                     url=None,
+                     params=None,
+                     data=None,
+                     stream=False):
+
+        headers = {'Authorization': 'Bearer {}'.format(self.access_token)}
+
+        if self.config.get('user_agent'):
+            headers['User-Agent'] = self.config['user_agent']
+
+        if method == "GET":
+            LOGGER.info(
+                f"Making {method} request to {url} with params: {params}")
+            response = self.session.get(url, headers=headers)
+        else:
+            raise Exception("Unsupported HTTP method")
+
+        LOGGER.info("Received code: {}".format(response.status_code))
+
+        return response.json()

--- a/tap_x_y/schemas/commerce_salesorderline.json
+++ b/tap_x_y/schemas/commerce_salesorderline.json
@@ -1,0 +1,219 @@
+{
+    "type": ["null", "object"],
+    "additionalProperties": true,
+    "properties": {
+        "revenueReport/reportDate": {
+            "type": ["null", "string"]
+        },
+        "charges/paid": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "amount": {
+                    "type": ["null", "integer"]
+                },
+                "currency": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "color": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "itemCategory": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "channel": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "charges/taxes": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "amount": {
+                    "type": ["null", "integer"]
+                },
+                "currency": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "channelType": {
+            "type": ["null", "string"]
+        },
+        "shipToLineCity": {
+            "type": ["null", "string"]
+        },
+        "division": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "itemSubCategory": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "sku": {
+            "type": ["null", "string"]
+        },
+        "charges/currency": {
+            "type": ["null", "string"]
+        },
+        "order": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "item": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "quantity": {
+            "type": ["null", "integer"]
+        },
+        "deliveryType": {
+            "type": ["null", "string"]
+        },
+        "charges/netAmountBeforeTax": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "amount": {
+                    "type": ["null", "integer"]
+                },
+                "currency": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "upc": {
+            "type": ["null", "string"]
+        },
+        "collection": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "charges/promotion": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "amount": {
+                    "type": ["null", "integer"]
+                },
+                "currency": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "itemImage": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "pointOfSale": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "size": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "fulfillmentLocation": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "style": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "orderDate": {
+            "type": ["null", "number"]
+        },
+        "charges/total": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "amount": {
+                    "type": ["null", "integer"]
+                },
+                "currency": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "customer": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+                "$uri": {
+                    "type": ["null", "string"]
+                }
+            }
+        }
+    }
+}

--- a/tap_x_y/streams.py
+++ b/tap_x_y/streams.py
@@ -1,0 +1,114 @@
+import os
+
+import humps
+import singer
+import singer.metrics
+from singer import metrics, metadata, Transformer, utils
+from singer.utils import strptime_to_utc
+from datetime import timedelta, datetime
+
+LOGGER = singer.get_logger()
+
+
+class Base:
+    def __init__(self, client=None, config=None, catalog=None, state=None):
+        self.client = client
+        self.config = config
+        self.catalog = catalog
+        self.state = state
+        self.top = 50
+        self.date_window_size = 1
+
+    @staticmethod
+    def get_abs_path(path):
+        return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
+
+    def load_schema(self):
+        schema_path = self.get_abs_path('schemas')
+        # pylint: disable=no-member
+        return singer.utils.load_json('{}/{}.json'.format(
+            schema_path, self.name))
+
+    def write_schema(self):
+        schema = self.load_schema()
+        # pylint: disable=no-member
+        return singer.write_schema(stream_name=self.name,
+                                   schema=schema,
+                                   key_properties=self.key_properties)
+
+    def write_state(self):
+        return singer.write_state(self.state)
+
+    def update_bookmark(self, stream, value):
+        if 'bookmarks' not in self.state:
+            self.state['bookmarks'] = {}
+        self.state['bookmarks'][stream] = value
+        LOGGER.info('Stream: {} - Write state, bookmark value: {}'.format(
+            stream, value))
+        self.write_state()
+
+    def get_bookmark(self, stream, default):
+        # default only populated on initial sync
+        if (self.state is None) or ('bookmarks' not in self.state):
+            return default
+        return self.state.get('bookmarks', {}).get(stream, default)
+
+    # Returns max key and date time for all replication key data in record
+    def max_from_replication_dates(self, record):
+        date_times = {
+            dt: strptime_to_utc(record[dt])
+            for dt in self.valid_replication_keys if record[dt] is not None
+        }
+        max_key = max(date_times)
+        return date_times[max_key]
+
+    def sync(self, mdata):
+        resources = self.client.get_all_resources(self.version,
+                                                  self.endpoint,
+                                                  top=self.top,
+                                                  orderby=self.orderby)
+
+        transformed_resources = humps.decamelize(resources)
+        yield resources
+
+class CommerceSalesOrderline(Base):
+    name = 'commerce_salesorderline'
+    key_properties = ['order']
+    replication_method = 'INCREMENTAL'
+    replication_key = 'orderDate'
+    endpoint = 'commerce.salesorderline-{salesorderline}'
+    valid_replication_keys = ['orderDate']
+    size = 100
+
+    def get_by_date(self, date):
+        filter_param = {
+            self.replication_key + '.filter': int(date.timestamp()) * 1000
+        }
+        return self.client.get_resources(self.endpoint.format(salesorderline=self.config.get('salesorderline')), filter_param)
+
+    def sync(self, mdata):
+        schema = self.load_schema()
+
+        # pylint: disable=unused-variable
+        with singer.metrics.job_timer(job_type=self.name) as timer:
+            with singer.metrics.record_counter(endpoint=self.name) as counter:
+
+                bookmark_date = self.get_bookmark(self.name, self.config.get('start_date'))
+                today = utils.now()
+
+                # Window the requests based on the tap configuration
+                date_window_start = strptime_to_utc(bookmark_date)
+
+                data = []
+                while date_window_start <= today:
+                    result = self.get_by_date(date_window_start)
+                    date_window_start = date_window_start + timedelta(
+                                days=self.date_window_size)
+                    data.extend(result)
+                yield data
+
+                    
+
+AVAILABLE_STREAMS = {
+    "commerce_salesorderline": CommerceSalesOrderline
+}


### PR DESCRIPTION
Adds:

* Base Tap resources(setup, inits, catalog)
* Client for XY API
* Stream for Salesorderline

Does not attempt:

* Data transforms
* Bookmarking

As no API docs available this is a WIP. API does support filtering(on any column) so where endpoints produce a date, will be able to do filtered INCREMENTAL sync with bookmarking.

```
https://developer.xyretail.com/_g/commerce.salesorderline-9518699780000999?orderDate.filter=1597276800000&from=460&size=100
```

Above pattern will allow us to process by calendar day. 

Endpoints are eccentric with what appear to be client specific guid suffixes:

```
https://developer.xyretail.com/_g/commerce.salesorderline-9518699780000999
```

Unknown if those are discoverable by the API. I haven't found a mechanism to do this yet. So are coding them into the tap config for the moment

```json
{
    "token": "TOKEN",
    "start_date": "2020-08-13T00:00:00Z",
    "salesorderline": "9518699780000999"
}
```